### PR TITLE
fix next button visibility on steps length changes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import React, {useState} from 'react'
+import React, {useState, useEffect } from 'react'
 
 const getNavStyles = (indx, length) => {
   let styles = []
@@ -59,6 +59,10 @@ export default function MultiStep(props) {
       setStepState(evt.currentTarget.value)
     }
   }
+  
+  useEffect(() => {
+    setStepState(compState);
+  }, [props.steps.length]);
 
   const renderSteps = () => 
     props.steps.map((s, i) => (


### PR DESCRIPTION
Next button is not showing up if the number of props.steps increased during multistep lifecycle

My case: 
I have 3 steps, if the third step is valid, I'll send a fourth step to props.steps of multistep component and if the fourth is valid, I'll send a fifth step to multistep and so forth until I finish my scenario journey.

The issue:
Steps: 
- If we just have three steps and I am already in the third one.
- After some user inputs, the third step got valid.
- My code automatically sends the fourth step to the multistep component.
- The nav styles get updated, but the buttons still as is, with NO next button visible.

Why: 
Because updating the buttons only happens on three events
When the user hits
1. The navigation list items
2. Next button
3. Previous button

The fix:
- Buttons should be updated on props.steps changes 

Implementation: 
- just re-calculate the stepState if there is any change to props.steps.length changes using useEffect react hook

`useEffect(() => {
    setStepState(compState);
}, [props.steps.length]);`