### PR TITLE
Steps without titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,23 @@ const MultiStep = import from 'react-multistep'
 
 Component accepts following, optional Props: 
 
-- 'showNavigation': controls if the navigation buttons are visable (default = true)
-- 'prevStyle' & 'nextStyle': control style of the navigation buttons
-- 'activeStep': define a start step, when not desired to start at the beggining 
-- 'steps': a required Prop, it takes an array of objects representing individual steps: 
+| PROPERTY       | DESCRIPTION                                                  | TYPE     | DEFAULT    | isRequired|
+|----------------|--------------------------------------------------------------|----------|------------|-----------|
+| showNavigation | controls if the navigation buttons are visable               |boolean   |true        |false      |
+| showTitles     | control either the steps title are visible or not            |boolean   |true        |false      |
+| prevStyle      | control style of the navigation buttons                      |style obj |null        |null       |
+| nextStyle      | control style of the navigation buttons                      |style obj |null        |false      |
+| stepCustomStyle| control style of step                                        |style obj |null        |false      |
+| steps          | it takes an array of objects representing individual steps   |Step      |null        |true       |
+
+Step:
+
+| PROPERTY  | DESCRIPTION                                 | TYPE       | DEFAULT    | isRequired|
+|-----------|---------------------------------------------|------------|------------|-----------|
+| component | the step representing component             |JSX.Element |null        |true       |
+| title     | the step title, present above the steps nav |text        |step index  |false      |
+
+
 
 ```javascript
 const steps = [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-multistep",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Responsive ReactJS multistep form component",
   "main": "dist/index.js",
   "files": [

--- a/src/MultiStep.jsx
+++ b/src/MultiStep.jsx
@@ -101,9 +101,11 @@ const getButtonsState = (indx, length) => {
 }
 
 export default function MultiStep (props) {
-  const { activeComponentClassName, inactiveComponentClassName } = props
+  const { activeComponentClassName, inactiveComponentClassName, stepCustomStyle } = props
   const showNav =
     typeof props.showNavigation === 'undefined' ? true : props.showNavigation
+  const showTitles =
+    typeof props.showTitles === 'undefined' ? true : props.showTitles
 
   const [activeStep] = useState(getStep(0, props.activeStep,  props.steps.length));
   const [stylesState, setStyles] = useState(getTopNavStyles(activeStep, props.steps.length))
@@ -141,33 +143,36 @@ export default function MultiStep (props) {
         return (
           <Li
             className={Todo}
+            style={props.stepCustomStyle}
             onClick={handleOnClick}
             key={i}
             value={i}
           >
-            <span>{s.title ??  i + 1}</span>
+            { showTitles && <span>{s.title ??  i + 1}</span> }
           </Li>
         )
       } else if (stylesState[i] === 'doing') {
         return (
           <Li
             className={Doing}
+            style={props.stepCustomStyle}
             onClick={handleOnClick}
             key={i}
             value={i}
           >
-            <span>{s.title ??  i + 1}</span>
+            { showTitles && <span>{s.title ??  i + 1}</span> }
           </Li>
         )
       } else {
         return (
           <Li
             className={Done}
+            style={props.stepCustomStyle}
             onClick={handleOnClick}
             key={i}
             value={i}
           >
-            <span>{s.title ??  i + 1}</span>
+            { showTitles && <span>{s.title ??  i + 1}</span> }
           </Li>
         )
       }

--- a/src/MultiStep.jsx
+++ b/src/MultiStep.jsx
@@ -143,7 +143,7 @@ export default function MultiStep (props) {
         return (
           <Li
             className={Todo}
-            style={props.stepCustomStyle}
+            style={stepCustomStyle}
             onClick={handleOnClick}
             key={i}
             value={i}
@@ -155,7 +155,7 @@ export default function MultiStep (props) {
         return (
           <Li
             className={Doing}
-            style={props.stepCustomStyle}
+            style={stepCustomStyle}
             onClick={handleOnClick}
             key={i}
             value={i}
@@ -167,7 +167,7 @@ export default function MultiStep (props) {
         return (
           <Li
             className={Done}
-            style={props.stepCustomStyle}
+            style={stepCustomStyle}
             onClick={handleOnClick}
             key={i}
             value={i}

--- a/src/stories/MultiStep.stories.jsx
+++ b/src/stories/MultiStep.stories.jsx
@@ -63,3 +63,29 @@ withStyledNavTemplate.args = {
   nextStyle: { background: '#33c3f0' },
   prevStyle: { background: '#33c3f0' }
 };
+
+
+export const withNoTitlesStepTemplate = Template.bind({});
+withNoTitlesStepTemplate.args = {
+  showTitles: false,
+  steps: [
+    { component: <StepOne /> },
+    { component: <StepTwo /> },
+    { component: <StepThree /> },
+    { component: <StepFour /> }
+  ],
+  activeStep: 1
+};
+
+export const withNoTitlesWithStepStyleStepTemplate = Template.bind({});
+withNoTitlesWithStepStyleStepTemplate.args = {
+  stepCustomStyle: {minWidth: '150px', maxWidth: '90vw'},
+  showTitles: false,
+  steps: [
+    { component: <StepOne /> },
+    { component: <StepTwo /> },
+    { component: <StepThree /> },
+    { component: <StepFour /> }
+  ],
+  activeStep: 1
+};


### PR DESCRIPTION
added the property showTitle - let you the ability to set either to show the titles
added the property stepCustomStyle - let customize the step style (for adding minWidth, maxWidth , etc.)
 
 added props table to readme for simple properties document
 
 bump the version for you to publish new version to npm and push new tag
 (This version includes:
  - tittle property for step
  - show titles property for invisible titles
  - stepCustomStyle for custom style step)   