### PR TITLE
convert to typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 package-lock.json
 dist
+build
 example/bundle.js
 example/index.js
 storybook/

--- a/example/app.js
+++ b/example/app.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import MultiStep from './dist/index'
+import MultiStep from './index'
 import StepOne from './stepOne'
 import StepTwo from './stepTwo'
 import StepThree from './stepThree'

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Responsive ReactJS multistep form component",
   "main": "dist/index.js",
   "files": [
+    "build/*.d.ts",
     "dist/index.js",
     "src/index.js",
     "src/MultiStep.jsx"
   ],
+  "types": "build/index.d.ts",
   "license": "MIT",
   "author": {
     "name": "@djidja8",
@@ -29,13 +31,15 @@
     "goober": "2.1.11"
   },
   "devDependencies": {
-    "esbuild": "0.17.4"
+    "esbuild": "0.17.4",
+    "typescript": "^4.9.5"
   },
   "peerDependencies": {
     "react": "18.2.0"
   },
   "scripts": {
-    "build": "esbuild ./src/index.js \"--define:process.env.NODE_ENV='production'\" --external:react --bundle --format=cjs --loader:.js=jsx --outdir=dist && cp -f ./dist/index.js ./example/dist/index.js",
+    "build:tsc": "tsc && cp -f ./dist/index.js ./example/index.js",
+    "build:bundle": "esbuild ./build/index.js \"--define:process.env.NODE_ENV='production'\" --external:react --bundle --format=cjs --loader:.js=jsx --outdir=dist && cp -f ./dist/index.js ./example/index.js",
     "publish": "npm publish ./"
   }
 }

--- a/src/MultiStep.tsx
+++ b/src/MultiStep.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { css, styled, setup } from 'goober'
+import { MultiStepPropsBase, Step} from './interfaces'
 
 setup(React.createElement)
 
@@ -82,7 +83,7 @@ const getStep = (defaultIndex, newIndex, length) => {
   }
 
 const getTopNavStyles = (indx, length) => {
-  const styles = []
+  const styles: string[] = []
   for (let i = 0; i < length; i++) {
     if (i < indx) {
       styles.push('done')
@@ -114,16 +115,19 @@ const getButtonsState = (indx, length, isValidState) => {
   }
 }
 
-export default function MultiStep (props) {
-  const {children } = props
-  let steps = props.steps ? props.steps : children  // for backward compatibility
-  const numberOfSteps = steps.length
-  const [childIsValid, setChildIsValid] = useState(true)
+export default function MultiStep (props: MultiStepPropsBase) {
+  const {children} = props
+  let stepsArray = props.steps
+  let steps: Step[] = []
+  if(!stepsArray && !children){
+    throw TypeError("missing children or steps in props");
+  }
 
+  const [childIsValid, setChildIsValid] = useState(true)
   const setIsChildInValidState = (isValid) => {
     setChildIsValid(isValid)
   }
-  
+
   if(children) { 
     let childrenWithProps = React.Children.map(children, (child, index) => {
       return React.cloneElement(child, {
@@ -131,11 +135,13 @@ export default function MultiStep (props) {
       }) 
     })
     // for backward compatibility we preserve 'steps' with components array:
-    steps = []
-    childrenWithProps.forEach(childComponent => {
-      steps.push({component: childComponent})
-    })
+    steps = childrenWithProps.map(childComponent => ({component: childComponent}))
+  }else{
+    steps = stepsArray
   }
+
+  const numberOfSteps = steps.length
+
 
   const stepCustomStyle = typeof props.stepCustomStyle === 'undefined' ? {} : props.stepCustomStyle
   const showNavButtons = typeof props.showNavigation === 'undefined' ? true : props.showNavigation
@@ -152,7 +158,7 @@ export default function MultiStep (props) {
     console.log(`From parent, child in valid state?: ${childIsValid}, button state: ${buttonsState.showNextBtn}`)
   }, [activeStep, childIsValid])
   
-  const setStepState = (indx, isValidState) => {
+  const setStepState = (indx: number, isValidState?: boolean) => {
     setStyles(getTopNavStyles(indx, numberOfSteps))
     setActiveStep(indx < numberOfSteps ? indx : activeStep)
     setButtons(getButtonsState(indx, numberOfSteps, isValidState))

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,16 @@
+import React from "react";
+
+export interface Step {
+    component: React.ReactElement;
+    title?: string;
+}
+
+export interface MultiStepPropsBase {
+    stepCustomStyle?: object;
+    showNavigation?: boolean;
+    showTitles?: boolean;
+    direction?: "row" | "column";
+    activeStep?: number;
+    children?: React.ReactElement[];
+    steps?: Step[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+      "jsx": "react-jsx",
+      "target": "ES2015",
+      "module": "CommonJS",
+      "lib": ["dom","dom.iterable","esnext"],
+      "moduleResolution": "node",
+      "resolveJsonModule": true,
+      "isolatedModules": true,
+      "removeComments": true,
+      "allowJs": true,
+      "skipLibCheck": true,
+      "esModuleInterop": true,
+      "allowSyntheticDefaultImports": true,
+      "preserveConstEnums": true,
+      "declaration": true,
+      "declarationMap": true,
+      "outDir": "./build",
+      "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "**/*.spec.ts"]
+  }


### PR DESCRIPTION
as requested in #80 

I converted the lib to typescript for easier definitions.

I tested the lib and it worked you can test it as well.
Now for building the lib you need to run extra stage:
`npm run build:tsc`
will create folder build/ 
that contains the typescript transpiling result
and then run:
`npm run build:bundle`
will create dist/index.js
that contains the bundle file

I added the declerations file to the included files of the module as well.
