### PR TITLE
enable nav buttons style and title in props

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,23 @@ and then, in your app (:warning:  see bellow for two supported usage patterns):
 
 MultiStep component accepts following props (all optional, except Steps array): 
 
-| PROPERTY       | DESCRIPTION                                                  | TYPE       | DEFAULT    | isRequired|
-|----------------|--------------------------------------------------------------|------------|------------|-----------|
-| showNavigation | controls if the navigation buttons are visable               |boolean     |true        |false      |
-| showTitles     | control either the steps title are visible or not            |boolean     |true        |false      |
-| prevStyle      | control style of the navigation buttons                      |style obj   |null        |false      |
-| nextStyle      | control style of the navigation buttons                      |style obj   |null        |false      |
-| stepCustomStyle| control style of step                                        |style obj   |null        |false      |
-| direction      | control the steps nav direction                              |column      |row         |false      |
-| activeStep     | it takes a number representing representing starting step    |number      |0           |false      |
-| steps          | it takes an array of objects representing individual steps   |Step        |null        |false      |
+| PROPERTY       | DESCRIPTION                                                  | TYPE        | DEFAULT    | isRequired|
+|----------------|--------------------------------------------------------------|-------------|------------|-----------|
+| showNavigation | controls if the navigation buttons are visable               |boolean      |true        |false      |
+| showTitles     | control either the steps title are visible or not            |boolean      |true        |false      |
+| prevButton     | configure the prev navigation button                         |NavButton    |null        |false      |
+| nextButton     | configure the naxt the navigation button                     |NavButton    |null        |false      |
+| stepCustomStyle| control style of step                                        |CSSProperties|null        |false      |
+| direction      | control the steps nav direction                              |column       |row         |false      |
+| activeStep     | it takes a number representing representing starting step    |number       |0           |false      |
+| steps          | it takes an array of objects representing individual steps   |Step         |null        |false      |
+
+
+NavButton
+| PROPERTY       | DESCRIPTION                                                  | TYPE         | DEFAULT    | isRequired|
+|----------------|--------------------------------------------------------------|--------------|------------|-----------|
+| title          | The display sting value of the navigation nutton             |string        |Prev / Next |false      |
+| style          | The css style of the navigation button                       |CSSProperties |null          |false      |
 
 
 #

--- a/example/app.js
+++ b/example/app.js
@@ -6,10 +6,6 @@ import StepTwo from './stepTwo'
 import StepThree from './stepThree'
 import StepFour from './stepFour'
 
-// custom styles
-const prevStyle = { background: '#33c3f0' }
-const nextStyle = { background: '#33c3f0' }
-
 const App = () => (
   <div className='container'>
     <MultiStep activeStep={0} prevButton={{style:{ background: 'red' }, title: 'prev step'}} >

--- a/example/app.js
+++ b/example/app.js
@@ -12,7 +12,7 @@ const nextStyle = { background: '#33c3f0' }
 
 const App = () => (
   <div className='container'>
-    <MultiStep activeStep={0} prevStyle={prevStyle} nextStyle={nextStyle}>
+    <MultiStep activeStep={0} prevButton={{style:{ background: 'red' }, title: 'prev step'}} >
       <StepOne title='Step 1'/>
       <StepTwo title='Step 2'/>
       <StepThree title='Step 3'/>

--- a/src/MultiStep.tsx
+++ b/src/MultiStep.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { css, styled, setup } from 'goober'
-import { MultiStepPropsBase, Step} from './interfaces'
+import { MultiStepPropsBase, NavButton, Step} from './interfaces'
 
 setup(React.createElement)
 
@@ -205,16 +205,18 @@ export default function MultiStep (props: MultiStepPropsBase) {
     }
   )
 
-  const renderButtonsNav = (show) =>
+  const renderButtonsNav = (show: boolean, prevButton?: NavButton, nextButton?: NavButton) =>
     show && (
       <div>
         <button onClick={previous}
+                style={prevButton?.style}
                 disabled={buttonsState.showPrevBtn ? false : true}>
-                Prev
+              {prevButton && prevButton.title ? <>{prevButton.title}</> : <>Prev</>}
         </button>
         <button onClick={next}
+                style={nextButton?.style}
                 disabled={buttonsState.showNextBtn ? false : true}>
-                Next
+              {nextButton && nextButton.title ? <>{nextButton.title}</> : <>Next</>}
         </button>
       </div>
     )
@@ -223,7 +225,7 @@ export default function MultiStep (props: MultiStepPropsBase) {
     <div style={{display: 'flex', flexDirection: directionType === 'column' ? 'row' : 'column'}}>
       <Ol className={directionType === 'column' ? ColumnDirection : RowDirection}>{renderTopNav()}</Ol>
       {steps[activeStep].component}
-      <div>{renderButtonsNav(showNavButtons)}</div>
+      <div>{renderButtonsNav(showNavButtons, props.prevButton, props.nextButton)}</div>
     </div>
   )
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,7 +11,7 @@ export interface NavButton{
 }
 
 export interface MultiStepPropsBase {
-    stepCustomStyle?: object
+    stepCustomStyle?: React.CSSProperties
     showNavigation?: boolean
     showTitles?: boolean
     direction?: "row" | "column"

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,6 +5,11 @@ export interface Step {
   component: React.ReactElement
 }
 
+export interface NavButton{
+  title?: string
+  style?: React.CSSProperties
+}
+
 export interface MultiStepPropsBase {
     stepCustomStyle?: object
     showNavigation?: boolean
@@ -13,4 +18,6 @@ export interface MultiStepPropsBase {
     activeStep?: number
     children?: React.ReactElement[]
     steps?: Step[]
+    prevButton?: NavButton
+    nextButton?: NavButton
 }


### PR DESCRIPTION
Added the ability to customize the title and style of each button in the navigation

<img width="491" alt="image" src="https://user-images.githubusercontent.com/17068656/219877546-e0d0c958-31ac-4e1a-b1d8-d72318b1966a.png">
