### PR TITLE
fix ReactDOM.render no longer support React 18

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import {createRoot} from 'react-dom/client'
 import MultiStep from 'react-multistep'
 import StepOne from './stepOne'
 import StepTwo from './stepTwo'
@@ -24,4 +24,5 @@ const App = () => (
   </div>
 )
 
-ReactDOM.render(<App />, document.getElementById('root'))
+const root = createRoot(document.getElementById('root'));
+root.render(<App />)

--- a/example/appOld.js
+++ b/example/appOld.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import {createRoot} from 'react-dom/client'
 import MultiStep from 'react-multistep'
 import StepOne from './stepOne'
 import StepTwo from './stepTwo'
@@ -30,4 +30,5 @@ const App = () => (
   </div>
 )
 
-ReactDOM.render(<App />, document.getElementById('root'))
+const root = createRoot(document.getElementById('root'));
+root.render(<App />)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "4.9.5"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "16-18"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
#105 

I have checked the example to make sure it runs correctly.

while fixing this issue I change the peer dependencies of the library, because as far as I know the package can support earlier version of react so why not let users with earlier version use it without any installation error.